### PR TITLE
Add "cryptoMethod" option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -234,15 +234,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-            "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
-            "dev": true
-        },
-        "acorn-dynamic-import": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-            "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+            "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
             "dev": true
         },
         "agent-base": {
@@ -273,9 +267,9 @@
             "dev": true
         },
         "ajv-keywords": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
-            "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+            "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
             "dev": true
         },
         "ansi-regex": {
@@ -612,9 +606,9 @@
             }
         },
         "base64-js": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
             "dev": true
         },
         "bcrypt-pbkdf": {
@@ -638,10 +632,20 @@
             "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
             "dev": true
         },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
         "bluebird": {
-            "version": "3.5.4",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-            "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
             "dev": true
         },
         "bn.js": {
@@ -753,9 +757,9 @@
             }
         },
         "buffer": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-            "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
             "dev": true,
             "requires": {
                 "base64-js": "^1.0.2",
@@ -788,31 +792,32 @@
             "dev": true
         },
         "cacache": {
-            "version": "11.3.2",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
-            "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+            "version": "12.0.3",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+            "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
             "dev": true,
             "requires": {
-                "bluebird": "^3.5.3",
+                "bluebird": "^3.5.5",
                 "chownr": "^1.1.1",
                 "figgy-pudding": "^3.5.1",
-                "glob": "^7.1.3",
+                "glob": "^7.1.4",
                 "graceful-fs": "^4.1.15",
+                "infer-owner": "^1.0.3",
                 "lru-cache": "^5.1.1",
                 "mississippi": "^3.0.0",
                 "mkdirp": "^0.5.1",
                 "move-concurrently": "^1.0.1",
                 "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
+                "rimraf": "^2.6.3",
                 "ssri": "^6.0.1",
                 "unique-filename": "^1.1.1",
                 "y18n": "^4.0.0"
             },
             "dependencies": {
                 "glob": {
-                    "version": "7.1.4",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-                    "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+                    "version": "7.1.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+                    "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -866,9 +871,9 @@
             }
         },
         "chokidar": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-            "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+            "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
             "dev": true,
             "requires": {
                 "anymatch": "^2.0.0",
@@ -955,15 +960,15 @@
             }
         },
         "chownr": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-            "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
             "dev": true
         },
         "chrome-trace-event": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
-            "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+            "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
@@ -1093,13 +1098,10 @@
             }
         },
         "console-browserify": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-            "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-            "dev": true,
-            "requires": {
-                "date-now": "^0.1.4"
-            }
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+            "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+            "dev": true
         },
         "constants-browserify": {
             "version": "1.0.0",
@@ -1202,9 +1204,9 @@
             }
         },
         "cyclist": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-            "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
+            "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
             "dev": true
         },
         "dashdash": {
@@ -1215,12 +1217,6 @@
             "requires": {
                 "assert-plus": "^1.0.0"
             }
-        },
-        "date-now": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-            "dev": true
         },
         "debug": {
             "version": "3.1.0",
@@ -1291,9 +1287,9 @@
             "dev": true
         },
         "des.js": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
-            "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+            "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
             "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
@@ -1352,9 +1348,9 @@
             }
         },
         "elliptic": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-            "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+            "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.4.0",
@@ -1453,9 +1449,9 @@
             }
         },
         "estraverse": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true
         },
         "esutils": {
@@ -1465,9 +1461,9 @@
             "dev": true
         },
         "events": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-            "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+            "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
             "dev": true
         },
         "evp_bytestokey": {
@@ -1662,6 +1658,13 @@
             "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
             "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
             "dev": true
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "dev": true,
+            "optional": true
         },
         "fill-range": {
             "version": "7.0.1",
@@ -1880,14 +1883,15 @@
             "dev": true
         },
         "fsevents": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-            "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+            "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
             "dev": true,
             "optional": true,
             "requires": {
+                "bindings": "^1.5.0",
                 "nan": "^2.12.1",
-                "node-pre-gyp": "^0.12.0"
+                "node-pre-gyp": "*"
             },
             "dependencies": {
                 "abbrev": {
@@ -1935,7 +1939,7 @@
                     }
                 },
                 "chownr": {
-                    "version": "1.1.1",
+                    "version": "1.1.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -1965,7 +1969,7 @@
                     "optional": true
                 },
                 "debug": {
-                    "version": "4.1.1",
+                    "version": "3.2.6",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -1992,12 +1996,12 @@
                     "optional": true
                 },
                 "fs-minipass": {
-                    "version": "1.2.5",
+                    "version": "1.2.7",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "^2.6.0"
                     }
                 },
                 "fs.realpath": {
@@ -2023,7 +2027,7 @@
                     }
                 },
                 "glob": {
-                    "version": "7.1.3",
+                    "version": "7.1.6",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2052,7 +2056,7 @@
                     }
                 },
                 "ignore-walk": {
-                    "version": "3.0.1",
+                    "version": "3.0.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2071,7 +2075,7 @@
                     }
                 },
                 "inherits": {
-                    "version": "2.0.3",
+                    "version": "2.0.4",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2113,7 +2117,7 @@
                     "optional": true
                 },
                 "minipass": {
-                    "version": "2.3.5",
+                    "version": "2.9.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2123,12 +2127,12 @@
                     }
                 },
                 "minizlib": {
-                    "version": "1.2.1",
+                    "version": "1.3.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "^2.9.0"
                     }
                 },
                 "mkdirp": {
@@ -2141,24 +2145,24 @@
                     }
                 },
                 "ms": {
-                    "version": "2.1.1",
+                    "version": "2.1.2",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "needle": {
-                    "version": "2.3.0",
+                    "version": "2.4.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "^4.1.0",
+                        "debug": "^3.2.6",
                         "iconv-lite": "^0.4.4",
                         "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
-                    "version": "0.12.0",
+                    "version": "0.14.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2172,7 +2176,7 @@
                         "rc": "^1.2.7",
                         "rimraf": "^2.6.1",
                         "semver": "^5.3.0",
-                        "tar": "^4"
+                        "tar": "^4.4.2"
                     }
                 },
                 "nopt": {
@@ -2186,13 +2190,22 @@
                     }
                 },
                 "npm-bundled": {
-                    "version": "1.0.6",
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "npm-normalize-package-bin": "^1.0.1"
+                    }
+                },
+                "npm-normalize-package-bin": {
+                    "version": "1.0.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
-                    "version": "1.4.1",
+                    "version": "1.4.7",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2263,7 +2276,7 @@
                     "optional": true
                 },
                 "process-nextick-args": {
-                    "version": "2.0.0",
+                    "version": "2.0.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2304,7 +2317,7 @@
                     }
                 },
                 "rimraf": {
-                    "version": "2.6.3",
+                    "version": "2.7.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2331,7 +2344,7 @@
                     "optional": true
                 },
                 "semver": {
-                    "version": "5.7.0",
+                    "version": "5.7.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2384,18 +2397,18 @@
                     "optional": true
                 },
                 "tar": {
-                    "version": "4.4.8",
+                    "version": "4.4.13",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
                         "chownr": "^1.1.1",
                         "fs-minipass": "^1.2.5",
-                        "minipass": "^2.3.4",
-                        "minizlib": "^1.1.1",
+                        "minipass": "^2.8.6",
+                        "minizlib": "^1.2.1",
                         "mkdirp": "^0.5.0",
                         "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.2"
+                        "yallist": "^3.0.3"
                     }
                 },
                 "util-deprecate": {
@@ -2420,7 +2433,7 @@
                     "optional": true
                 },
                 "yallist": {
-                    "version": "3.0.3",
+                    "version": "3.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2732,10 +2745,10 @@
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
-        "indexof": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-            "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+        "infer-owner": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+            "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
             "dev": true
         },
         "inflight": {
@@ -3058,14 +3071,6 @@
             "dev": true,
             "requires": {
                 "yallist": "^3.0.2"
-            },
-            "dependencies": {
-                "yallist": {
-                    "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-                    "dev": true
-                }
             }
         },
         "make-dir": {
@@ -3304,9 +3309,9 @@
             "dev": true
         },
         "nan": {
-            "version": "2.13.2",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-            "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
             "dev": true,
             "optional": true
         },
@@ -3341,9 +3346,9 @@
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
         "node-libs-browser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
-            "integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+            "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
             "dev": true,
             "requires": {
                 "assert": "^1.1.1",
@@ -3356,7 +3361,7 @@
                 "events": "^3.0.0",
                 "https-browserify": "^1.0.0",
                 "os-browserify": "^0.3.0",
-                "path-browserify": "0.0.0",
+                "path-browserify": "0.0.1",
                 "process": "^0.11.10",
                 "punycode": "^1.2.4",
                 "querystring-es3": "^0.2.0",
@@ -3368,7 +3373,7 @@
                 "tty-browserify": "0.0.0",
                 "url": "^0.11.0",
                 "util": "^0.11.0",
-                "vm-browserify": "0.0.4"
+                "vm-browserify": "^1.0.1"
             },
             "dependencies": {
                 "punycode": {
@@ -3560,26 +3565,26 @@
             "dev": true
         },
         "pako": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-            "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
             "dev": true
         },
         "parallel-transform": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-            "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
+            "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
             "dev": true,
             "requires": {
-                "cyclist": "~0.2.2",
+                "cyclist": "^1.0.1",
                 "inherits": "^2.0.3",
                 "readable-stream": "^2.1.5"
             }
         },
         "parse-asn1": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
-            "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+            "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
             "dev": true,
             "requires": {
                 "asn1.js": "^4.0.0",
@@ -3603,9 +3608,9 @@
             "dev": true
         },
         "path-browserify": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-            "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+            "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
             "dev": true
         },
         "path-dirname": {
@@ -4073,18 +4078,18 @@
             "dev": true
         },
         "rimraf": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.3"
             },
             "dependencies": {
                 "glob": {
-                    "version": "7.1.4",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-                    "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+                    "version": "7.1.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+                    "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -4154,9 +4159,9 @@
             "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
         },
         "serialize-javascript": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
-            "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+            "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
             "dev": true
         },
         "set-blocking": {
@@ -4481,9 +4486,9 @@
             }
         },
         "stream-shift": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
             "dev": true
         },
         "string-width": {
@@ -4544,38 +4549,38 @@
             "dev": true
         },
         "terser": {
-            "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-            "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.3.tgz",
+            "integrity": "sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==",
             "dev": true,
             "requires": {
-                "commander": "^2.19.0",
+                "commander": "^2.20.0",
                 "source-map": "~0.6.1",
-                "source-map-support": "~0.5.10"
+                "source-map-support": "~0.5.12"
             },
             "dependencies": {
                 "commander": {
-                    "version": "2.20.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-                    "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
                     "dev": true
                 }
             }
         },
         "terser-webpack-plugin": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.4.tgz",
-            "integrity": "sha512-64IiILNQlACWZLzFlpzNaG0bpQ4ytaB7fwOsbpsdIV70AfLUmIGGeuKL0YV2WmtcrURjE2aOvHD4/lrFV3Rg+Q==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+            "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
             "dev": true,
             "requires": {
-                "cacache": "^11.3.2",
-                "find-cache-dir": "^2.0.0",
+                "cacache": "^12.0.2",
+                "find-cache-dir": "^2.1.0",
                 "is-wsl": "^1.1.0",
                 "schema-utils": "^1.0.0",
-                "serialize-javascript": "^1.7.0",
+                "serialize-javascript": "^2.1.2",
                 "source-map": "^0.6.1",
-                "terser": "^3.17.0",
-                "webpack-sources": "^1.3.0",
+                "terser": "^4.1.2",
+                "webpack-sources": "^1.4.0",
                 "worker-farm": "^1.7.0"
             }
         },
@@ -4590,9 +4595,9 @@
             }
         },
         "timers-browserify": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-            "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+            "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
             "dev": true,
             "requires": {
                 "setimmediate": "^1.0.4"
@@ -4775,9 +4780,9 @@
             }
         },
         "unique-slug": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
-            "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+            "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
             "dev": true,
             "requires": {
                 "imurmurhash": "^0.1.4"
@@ -4824,9 +4829,9 @@
             }
         },
         "upath": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-            "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+            "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
             "dev": true
         },
         "uri-js": {
@@ -4917,13 +4922,10 @@
             }
         },
         "vm-browserify": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-            "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-            "dev": true,
-            "requires": {
-                "indexof": "0.0.1"
-            }
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+            "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+            "dev": true
         },
         "vscode": {
             "version": "1.1.34",
@@ -5009,37 +5011,48 @@
             }
         },
         "webpack": {
-            "version": "4.31.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.31.0.tgz",
-            "integrity": "sha512-n6RVO3X0LbbipoE62akME9K/JI7qYrwwufs20VvgNNpqUoH4860KkaxJTbGq5bgkVZF9FqyyTG/0WPLH3PVNJA==",
+            "version": "4.41.6",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.6.tgz",
+            "integrity": "sha512-yxXfV0Zv9WMGRD+QexkZzmGIh54bsvEs+9aRWxnN8erLWEOehAKUTeNBoUbA6HPEZPlRo7KDi2ZcNveoZgK9MA==",
             "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.8.5",
                 "@webassemblyjs/helper-module-context": "1.8.5",
                 "@webassemblyjs/wasm-edit": "1.8.5",
                 "@webassemblyjs/wasm-parser": "1.8.5",
-                "acorn": "^6.0.5",
-                "acorn-dynamic-import": "^4.0.0",
-                "ajv": "^6.1.0",
-                "ajv-keywords": "^3.1.0",
-                "chrome-trace-event": "^1.0.0",
+                "acorn": "^6.2.1",
+                "ajv": "^6.10.2",
+                "ajv-keywords": "^3.4.1",
+                "chrome-trace-event": "^1.0.2",
                 "enhanced-resolve": "^4.1.0",
-                "eslint-scope": "^4.0.0",
+                "eslint-scope": "^4.0.3",
                 "json-parse-better-errors": "^1.0.2",
-                "loader-runner": "^2.3.0",
-                "loader-utils": "^1.1.0",
-                "memory-fs": "~0.4.1",
-                "micromatch": "^3.1.8",
-                "mkdirp": "~0.5.0",
-                "neo-async": "^2.5.0",
-                "node-libs-browser": "^2.0.0",
+                "loader-runner": "^2.4.0",
+                "loader-utils": "^1.2.3",
+                "memory-fs": "^0.4.1",
+                "micromatch": "^3.1.10",
+                "mkdirp": "^0.5.1",
+                "neo-async": "^2.6.1",
+                "node-libs-browser": "^2.2.1",
                 "schema-utils": "^1.0.0",
-                "tapable": "^1.1.0",
-                "terser-webpack-plugin": "^1.1.0",
-                "watchpack": "^1.5.0",
-                "webpack-sources": "^1.3.0"
+                "tapable": "^1.1.3",
+                "terser-webpack-plugin": "^1.4.3",
+                "watchpack": "^1.6.0",
+                "webpack-sources": "^1.4.1"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.11.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+                    "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "braces": {
                     "version": "2.3.2",
                     "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
@@ -5068,6 +5081,12 @@
                             }
                         }
                     }
+                },
+                "fast-deep-equal": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+                    "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+                    "dev": true
                 },
                 "fill-range": {
                     "version": "4.0.0",
@@ -5195,9 +5214,9 @@
             }
         },
         "webpack-sources": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
-            "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+            "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
             "dev": true,
             "requires": {
                 "source-list-map": "^2.0.0",
@@ -5244,15 +5263,21 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "xtend": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
             "dev": true
         },
         "y18n": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
             "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "dev": true
+        },
+        "yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -186,6 +186,16 @@
                     "description": "Go inside subdirectories to encrypt/decrypt files",
                     "type": "boolean",
                     "default": false
+                },
+                "secretlens.cryptoMethod": {
+                    "title": "Crypto method",
+                    "description": "How the secrets are encrypted.\ndefault: legacy implementation\npbkdf2: openssl password based key derivation function 2\n    equivalent to shell command [openssl enc -aes-256-cbc -pbkdf2 | xxd -p]\n    decrypt with [xxd -p -r | openssl enc -aes-256-cbc -pbkdf2 -d]",
+                    "type": "string",
+                    "enum": [
+                        "default",
+                        "pbkdf2"
+                    ],
+                    "default": "default"
                 }
             }
         }
@@ -207,7 +217,7 @@
         "tslint": "^5.16.0",
         "typescript": "^3.4.5",
         "vscode": "^1.1.34",
-        "webpack": "^4.31.0",
+        "webpack": "^4.41.6",
         "webpack-cli": "^3.3.6"
     },
     "dependencies": {

--- a/src/secretlens/SecretLensFunction.ts
+++ b/src/secretlens/SecretLensFunction.ts
@@ -37,7 +37,7 @@ export class SecretLensFunction implements interfaces.ISecretLensFunction {
             // '53616c7465645f5f' is hexa for string "Salted__".
             // This is added for compatibility with the openssl command.
             // Specifically, with openssl salt generation algorithm, the first 8 bytes
-            // are always "Salted__" and only the last five bytes are random.
+            // are always "Salted__" and the last 8 bytes are random.
         } else {
             var encrypted: string = "";
             var saltedPassword = this.password;

--- a/src/secretlens/SecretLensFunction.ts
+++ b/src/secretlens/SecretLensFunction.ts
@@ -14,37 +14,75 @@ export class SecretLensFunction implements interfaces.ISecretLensFunction {
         this.provider = provider;
     }
 
-    public encrypt(inputText: string): string {
-        var encrypted: string = "";
-        var saltedPassword = this.password;
-        if (this.useSalt) {
-            var salt = crypto.randomBytes(this.saltSize).toString('hex');
-            saltedPassword = salt + this.password;
-        }
-        const cipher = crypto.createCipher('aes-256-cbc', saltedPassword);
-        encrypted = cipher.update(inputText, 'utf8', 'hex');
-        encrypted += cipher.final('hex');
-        if (this.useSalt) {
-            return salt + encrypted;
+    public encrypt(inputText: string, cryptoMethod: string): string {
+
+        if (cryptoMethod == "pbkdf2") {
+
+            // Equivalent shell command: openssl enc -aes-256-cbc -pbkdf2 | xxd -p | tr -d "\n"
+            //
+            var binsalt = crypto.randomBytes(8);
+            let derivedKey = crypto.pbkdf2Sync(this.password, binsalt, 10000, 48, 'sha256');
+            let key = derivedKey.slice(0, 32);
+            let iv = derivedKey.slice(32, 48);
+
+            let cipher = crypto.createCipheriv('aes-256-cbc', key, iv)
+            var encrypted = cipher.update(inputText, 'utf8', 'hex');
+            encrypted += cipher.final('hex');
+            return 'pbkdf2:53616c7465645f5f' + binsalt.toString('hex') + encrypted;
         } else {
-            return encrypted;
+            var encrypted: string = "";
+            var saltedPassword = this.password;
+            if (this.useSalt) {
+                var salt = crypto.randomBytes(this.saltSize).toString('hex');
+                saltedPassword = salt + this.password;
+            }
+            const cipher = crypto.createCipher('aes-256-cbc', saltedPassword);
+            encrypted = cipher.update(inputText, 'utf8', 'hex');
+            encrypted += cipher.final('hex');
+            if (this.useSalt) {
+                return salt + encrypted;
+            } else {
+                return encrypted;
+            }
         }
     }
 
     public decrypt(inputText: string): string {
-        var decrypted: string = "";
-        var ended = false;
-        var saltedPassword = this.password;
-        if (this.useSalt) {
-            var salt = inputText.substring(0, this.saltSize * 2);
-            inputText = inputText.replace(salt, "");
-            saltedPassword = salt + this.password;
+
+        if (inputText.search("pbkdf2:") == 0) {
+
+            // Equivalent shell command: xxd -p -r | openssl enc -aes-256-cbc -pbkdf2 -d
+            //
+            inputText = inputText.slice(7);
+            var hexsalt = inputText.substring(16, 32);
+            var binsalt = Buffer.from(hexsalt, 'hex')
+            inputText = inputText.slice(32);
+            // Derive a key using PBKDF2.
+            // https://github.com/nodejs/node/issues/27802
+            let derivedKey = crypto.pbkdf2Sync(this.password, binsalt, 10000, 48, 'sha256');
+            let key = derivedKey.slice(0, 32);
+            let iv = derivedKey.slice(32, 48);
+
+            let decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+            var decrypted = decipher.update(inputText, 'hex', 'utf8');
+            decrypted += decipher.final('utf8');
+            
+            return decrypted;
+        } else {
+            var decrypted: string = "";
+            var ended = false;
+            var saltedPassword = this.password;
+            if (this.useSalt) {
+                var salt = inputText.substring(0, this.saltSize * 2);
+                inputText = inputText.replace(salt, "");
+                saltedPassword = salt + this.password;
+            }
+            const decipher = crypto.createDecipher('aes-256-cbc', saltedPassword);
+            decrypted = decipher.update(inputText, 'hex', 'utf8');
+            decrypted += decipher.final('utf8');
+            ended = true;
+            return decrypted;
         }
-        const decipher = crypto.createDecipher('aes-256-cbc', saltedPassword);
-        decrypted = decipher.update(inputText, 'hex', 'utf8');
-        decrypted += decipher.final('utf8');
-        ended = true;
-        return decrypted;
     }
 
     public setUseSalt(useSalt: boolean) {

--- a/src/secretlens/SecretLensFunction.ts
+++ b/src/secretlens/SecretLensFunction.ts
@@ -20,7 +20,12 @@ export class SecretLensFunction implements interfaces.ISecretLensFunction {
 
             // Equivalent shell command: openssl enc -aes-256-cbc -pbkdf2 | xxd -p | tr -d "\n"
             //
-            var binsalt = crypto.randomBytes(8);
+            var binsalt;
+            if (this.useSalt) {
+                binsalt = crypto.randomBytes(8);
+            } else {
+                binsalt = Buffer.alloc(8);
+            }
             let derivedKey = crypto.pbkdf2Sync(this.password, binsalt, 10000, 48, 'sha256');
             let key = derivedKey.slice(0, 32);
             let iv = derivedKey.slice(32, 48);

--- a/src/secretlens/SecretLensFunction.ts
+++ b/src/secretlens/SecretLensFunction.ts
@@ -29,6 +29,10 @@ export class SecretLensFunction implements interfaces.ISecretLensFunction {
             var encrypted = cipher.update(inputText, 'utf8', 'hex');
             encrypted += cipher.final('hex');
             return 'pbkdf2:53616c7465645f5f' + binsalt.toString('hex') + encrypted;
+            // '53616c7465645f5f' is hexa for string "Salted__".
+            // This is added for compatibility with the openssl command.
+            // Specifically, with openssl salt generation algorithm, the first 8 bytes
+            // are always "Salted__" and only the last five bytes are random.
         } else {
             var encrypted: string = "";
             var saltedPassword = this.password;

--- a/src/secretlens/SecretLensProvider.ts
+++ b/src/secretlens/SecretLensProvider.ts
@@ -147,7 +147,7 @@ export class SecretLensProvider implements vscode.CodeLensProvider, vscode.Dispo
             readFile(uri.fsPath, (err, data) => {
                 if (err) { throw err; }
                 const originalText = data.toString();
-                const encrypted = this.secretLensFunction.encrypt(data.toString());
+                const encrypted = this.secretLensFunction.encrypt(data.toString(), this.config.get("cryptoMethod"));
                 const text = this.startToken + encrypted + (!this.config.get("excludeEnd") ? this.endToken : "");
                 const regex = new RegExp(this.regex);
                 if (!regex.test(data.toString())) {
@@ -232,7 +232,7 @@ export class SecretLensProvider implements vscode.CodeLensProvider, vscode.Dispo
                     var text = editor.document.getText(range);
                     const regex = new RegExp(this.regex);
                     if (!regex.test(text) && text.length > 0) {
-                        var encrypted = this.secretLensFunction.encrypt(text);
+                        var encrypted = this.secretLensFunction.encrypt(text, this.config.get("cryptoMethod"));
                         text = this.startToken + encrypted + (!this.config.get("excludeEnd") ? this.endToken : "");
                         edits.replace(range, text);
                         replaces.push(new vscode.Selection(range.start, range.start.translate(0, text.length)));

--- a/src/secretlens/interfaces.ts
+++ b/src/secretlens/interfaces.ts
@@ -1,5 +1,5 @@
 export interface ISecretLensFunction {
-    encrypt(inputText: string): string;
+    encrypt(inputText: string, cryptoMetho: string): string;
     decrypt(inputText: string): string;
     askPassword(): void;
     shouldAskForPassword: boolean;

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -25,12 +25,19 @@ describe("secretlens", () => {
     context("encrypt", () => {
         it("should encrypt correctly", () => {
             provider.getFunction().setUseSalt(false);
-            var tests = [{
-                text: 'test',
-                encrypted: '46800f525d58bb6a3886d37a247bd4db'
-            }];
+            var tests = [
+                {
+                    method: 'default',
+                    text: 'test',
+                    encrypted: '46800f525d58bb6a3886d37a247bd4db'
+                },{
+                    method: 'pbkdf2',
+                    text: 'test',
+                    encrypted: 'pbkdf2:53616c7465645f5f0000000000000000b455bed4b84f8cbea2afb755feeac6fe'
+                }
+            ];
             tests.forEach(test => {
-                assert.equal(provider.getFunction().encrypt(test.text), test.encrypted);
+                assert.equal(provider.getFunction().encrypt(test.text, test.method), test.encrypted);
             });
         });
     });
@@ -41,6 +48,9 @@ describe("secretlens", () => {
                 {
                     text: 'test',
                     encrypted: '7cdfda208c21275a6188573a4f2476e6c2e89f9579107a813ab8defab1f69956'
+                },{
+                    text: 'test',
+                    encrypted: 'pbkdf2:53616c7465645f5f8e30a5ff83f7d2612164ab18781b486929de0746f3157a27'
                 }
             ];
             tests.forEach(test => {


### PR DESCRIPTION
The "secretlens.cryptoMethod option lets the user choose the way the
secrets are encrypted. Two methods are implemented:
- default (for backward compatibility)
- pbkdf2

pbkdf2:
- fixes the issue with crypto.createCipher and crypto.createDecipher
  deprecation
- is equivalent to:
  openssl enc -aes-256-cbc -pbkdf2 | xxd -p | tr -d
- secrets can be manually decrypted with:
  xxd -p -r | openssl enc -aes-256-cbc -pbkdf2 -d